### PR TITLE
Fix release.yml with version input and namespace update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+
   workflow_dispatch:
     inputs:
       version:
@@ -14,7 +15,6 @@ on:
 env:
   IMAGE_NAME: oetsv-parser
   DOCKERHUB_NAMESPACE: coeptus
-  GHCR_NAMESPACE: coeptus
 
 jobs:
   test:
@@ -40,6 +40,7 @@ jobs:
   publish_images:
     needs: test
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
@@ -94,11 +95,13 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+
           tags: |
             ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
             ${{ env.DOCKERHUB_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+
           labels: |
             org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
Updated release workflow to include workflow_dispatch input for version and adjusted GHCR namespace to use repository owner.